### PR TITLE
GH-29: Add docker build setup and GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -1,0 +1,28 @@
+env:
+  CI: true
+jobs:
+  deploy:
+    environment:
+      name: main
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash ./scripts/ci/build.sh
+      - name: Upload doc folder
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./systems/web/dist
+      - id: deployment
+        name: Deploy doc with PDF to GitHub Pages
+        uses: actions/deploy-pages@v4
+name: deploy-github-page-after-push-main
+
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+  id-token: write
+  pages: write

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,11 @@
+services:
+  cms:
+    command: ./scripts/docker/start.sh --build
+  web:
+    command: ./scripts/docker/build.sh
+    volumes:
+      - bind:
+          create_host_path: true
+        source: ./systems/web/dist
+        target: /app/dist
+        type: bind

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+docker compose -f docker-compose.yml -f docker-compose.build.yml up --build \
+ --exit-code-from web \
+ --abort-on-container-exit

--- a/systems/cms/scripts/docker/start.sh
+++ b/systems/cms/scripts/docker/start.sh
@@ -2,17 +2,20 @@
 
 set -ex
 
-IS_DEV=${1:---dev}
+MODE=${1:---dev}
 
 cp ./vite.config.js ./node_modules/@tinacms/app
 
-if [ "$IS_DEV" == "--dev" ]; then
+if [ "$MODE" == "--dev" ]; then
   echo "Start CMS service in dev mode"
   npx tinacms dev
-elif [ "$IS_DEV" == "--test" ]; then
+elif [ "$MODE" == "--test" ]; then
   echo "Start CMS service in test mode"
   npx tinacms dev --noWatch
+elif [ "$MODE" == "--build" ]; then
+  echo "Start CMS service in build mode"
+  npx tinacms dev --noWatch
 else
-    echo "Invalid argument: $IS_DEV"
+    echo "Invalid argument: $MODE"
     exit 1
 fi

--- a/systems/web/scripts/docker/start.sh
+++ b/systems/web/scripts/docker/start.sh
@@ -2,16 +2,16 @@
 
 set -ex
 
-IS_DEV=${1:---dev}
+MODE=${1:---dev}
 
-if [ "$IS_DEV" == "--dev" ]; then
+if [ "$MODE" == "--dev" ]; then
   echo "Start Web frontend in dev mode"
   npx astro dev --host
-elif [ "$IS_DEV" == "--test" ]; then
+elif [ "$MODE" == "--test" ]; then
   echo "Start Web frontend in test mode"
   npx astro build
   npx astro preview --host
 else
-    echo "Invalid argument: $IS_DEV"
+    echo "Invalid argument: $MODE"
     exit 1
 fi


### PR DESCRIPTION
this close #29
Introduce `docker-compose.build.yml` and `build.sh` to support building and running containers in build mode. Update CMS start script to handle a `--build` flag. Add a GitHub Actions workflow to deploy `web/dist` to GitHub Pages on pushes to the main branch.