### PR TITLE
GH-29: Update deploy workflow to clarify deployment action

### DIFF
--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           path: ./systems/web/dist
       - id: deployment
-        name: Deploy doc with PDF to GitHub Pages
+        name: Deploy static site to GitHub Pages
         uses: actions/deploy-pages@v4
 name: deploy-github-page-after-push-main
 


### PR DESCRIPTION
this part of #29
Renamed the job description for better clarity, reflecting that it deploys the static site rather than focusing on specific contents like PDFs. This improves readability and avoids confusion in the workflow.