### PR TITLE
GH-29: Update base URL to include '/portfolio' across the project

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,7 @@ services:
         condition: service_healthy
     entrypoint: /bin/bash
     environment:
-      - TESTS_WEB_BASE_URL=http://web:4321
-      - TESTS_CMS_ENDPOINT=http://cms:4001/graphql
+      - TESTS_WEB_BASE_URL=http://web:4321/
+      - TESTS_CMS_BASE_URL=http://cms:4001/
   web:
     command: ./scripts/docker/start.sh --test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,4 @@ services:
     entrypoint: /bin/sh
     environment:
       - WEB_CMS_BASE_URL=http://cms:4001/
-      - WEB_BASE_URL=http://localhost:4321/
+      - WEB_BASE_URL=http://localhost:4321

--- a/systems/tests/tests/cms.ts
+++ b/systems/tests/tests/cms.ts
@@ -1,12 +1,12 @@
 import { formatGqlQuery, gql } from './graphql.ts';
 
-const cmsEndpoint = process.env['TESTS_CMS_ENDPOINT'];
-if (!cmsEndpoint) {
-  throw new Error('TESTS_CMS_ENDPOINT is not defined');
+const cmsBaseUrl = process.env['TESTS_CMS_BASE_URL'];
+if (!cmsBaseUrl) {
+  throw new Error('TESTS_CMS_BASE_URL is not defined');
 }
 
 function gqlRequest(query: ReturnType<typeof gql>, variables?: unknown) {
-  return fetch(cmsEndpoint!, {
+  return fetch(new URL('/graphql', cmsBaseUrl), {
     body: JSON.stringify({
       query: formatGqlQuery(query),
       variables,

--- a/systems/tests/tests/web.ts
+++ b/systems/tests/tests/web.ts
@@ -3,4 +3,4 @@ if (!TESTS_WEB_BASE_URL) {
   throw new Error('TESTS_WEB_BASE_URL is not defined');
 }
 
-export const whoAmIPage = new URL('/who-am-i', TESTS_WEB_BASE_URL);
+export const whoAmIPage = new URL('/portfolio/who-am-i', TESTS_WEB_BASE_URL);

--- a/systems/web/astro.config.mjs
+++ b/systems/web/astro.config.mjs
@@ -4,7 +4,9 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  base: 'portfolio',
   integrations: [react({ include: ['**/react/*'] })],
+  site: 'https://neviaumi.github.io/',
   vite: {
     ssr: {
       noExternal: /@mui\/.*?/,

--- a/systems/web/scripts/docker/health-check.sh
+++ b/systems/web/scripts/docker/health-check.sh
@@ -2,4 +2,4 @@
 
 set -ex
 curl --fail-with-body --request GET \
-"${WEB_BASE_URL}/healthz"
+"${WEB_BASE_URL}/portfolio/healthz"

--- a/systems/web/src/components/react/NavigationBar.tsx
+++ b/systems/web/src/components/react/NavigationBar.tsx
@@ -54,7 +54,7 @@ export function DrawerToggleButton({ title }: { title: string }) {
         />
         <List>
           <ListItem>
-            <ListItemButton component={'a'} href={'/who-am-i'}>
+            <ListItemButton component={'a'} href={'/portfolio/who-am-i'}>
               <ListItemIcon>
                 <PersonOutlineOutlinedIcon
                   sx={{
@@ -69,7 +69,7 @@ export function DrawerToggleButton({ title }: { title: string }) {
             </ListItemButton>
           </ListItem>
           <ListItem>
-            <ListItemButton component={'a'} href={'/core-values'}>
+            <ListItemButton component={'a'} href={'/portfolio/core-values'}>
               <ListItemIcon>
                 <DiamondOutlinedIcon
                   sx={{
@@ -84,7 +84,7 @@ export function DrawerToggleButton({ title }: { title: string }) {
             </ListItemButton>
           </ListItem>
           <ListItem>
-            <ListItemButton component={'a'} href={'/experiences'}>
+            <ListItemButton component={'a'} href={'/portfolio/experiences'}>
               <ListItemIcon>
                 <ScienceOutlinedIcon
                   sx={{
@@ -99,7 +99,7 @@ export function DrawerToggleButton({ title }: { title: string }) {
             </ListItemButton>
           </ListItem>
           <ListItem>
-            <ListItemButton component={'a'} href={'/skills'}>
+            <ListItemButton component={'a'} href={'/portfolio/skills'}>
               <ListItemIcon>
                 <HandymanOutlinedIcon
                   sx={{
@@ -114,7 +114,7 @@ export function DrawerToggleButton({ title }: { title: string }) {
             </ListItemButton>
           </ListItem>
           <ListItem>
-            <ListItemButton component={'a'} href={'/faq'}>
+            <ListItemButton component={'a'} href={'/portfolio/faq'}>
               <ListItemIcon>
                 <QuizOutlinedIcon
                   sx={{

--- a/systems/web/src/components/who-am-i/react/CoreValuesSection.tsx
+++ b/systems/web/src/components/who-am-i/react/CoreValuesSection.tsx
@@ -15,7 +15,9 @@ export async function prepareCoreValuesProps(
   return Promise.all(
     values.map(async value => {
       await cms.copyAssetToPublicFolder(value.icon);
-      return value;
+      return Object.assign(value, {
+        icon: `/portfolio/${value.icon}`,
+      });
     }),
   );
 }

--- a/systems/web/src/layouts/Layout.astro
+++ b/systems/web/src/layouts/Layout.astro
@@ -16,7 +16,7 @@ const { title } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, minimal-ui">
 		<!--<meta name="viewport" content="width=device-width" />-->
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="icon" type="image/svg+xml" href="/portfolio/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 	</head>


### PR DESCRIPTION
this fix #29
Updated paths, links, and site configuration to include the '/portfolio' base URL. This ensures proper routing and asset references when deploying under a subdirectory. Adjustments include navigation links, favicon path, and CMS icon handling.