### PR TITLE
GH-38: Add resume page with dynamic script loading

### DIFF
--- a/systems/web/src/pages/resume.astro
+++ b/systems/web/src/pages/resume.astro
@@ -1,0 +1,20 @@
+---
+import Layout from '../layouts/Layout.astro';
+const title = "Resume"
+---
+
+<Layout title={title}>
+    <script>
+        const resumeBaseUrl = 'https://neviaumi.github.io/resume.json/'
+        fetch('https://neviaumi.github.io/resume.json/.vite/manifest.json')
+            .then(response => response.json())
+            .then(json => {
+                const script = document.createElement('script');
+                script.setAttribute('crossorigin', '');
+                script.setAttribute('type', "module");
+                script.setAttribute('src', `${resumeBaseUrl}${json['index.html'].file}`);
+                document.head.appendChild(script)
+            })
+    </script>
+    <json-resume></json-resume>
+</Layout>


### PR DESCRIPTION
this part of #38
Created a new `resume.astro` page that dynamically fetches a script from a remote JSON manifest and injects it into the document. This enables loading additional resources for the resume component. Ensures flexibility and decoupled script management.