### PR TITLE
GH-38: Rename Resume component to ResumeLoader and fix loading logic.

### DIFF
--- a/systems/web/src/components/resume/react/ResumeLoader.tsx
+++ b/systems/web/src/components/resume/react/ResumeLoader.tsx
@@ -2,12 +2,12 @@ import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
 import React, { useEffect, useState } from 'react';
 
-export default function Resume() {
+export default function ResumeLoader() {
   const [isLoading, setIsLoading] = useState(true);
   useEffect(
     function loadWebComponents() {
       const resumeBaseUrl = 'https://neviaumi.github.io/resume.json/';
-      if (!isLoading) {
+      if (isLoading) {
         fetch(`${resumeBaseUrl}.vite/manifest.json`)
           .then(response => response.json())
           .then(json => {

--- a/systems/web/src/pages/resume.astro
+++ b/systems/web/src/pages/resume.astro
@@ -1,7 +1,7 @@
 ---
 import {Page, Main} from "../components/react/PageContainer"
 import NavigationBar, {DrawerToggleButton} from '../components/react/NavigationBar.tsx';
-import ResumeLoader from "../components/resume/react/Resume.tsx"
+import ResumeLoader from "../components/resume/react/ResumeLoader.tsx"
 import Layout from '../layouts/Layout.astro';
 const title = "Resume"
 ---


### PR DESCRIPTION
this fix #38
The component was renamed to better reflect its functionality as a loader. Additionally, a logical error in the loading condition was corrected. The updated code ensures proper fetching behavior for the resume data.