### PR TITLE
GH-38: Add "Resume" link to SummarySection and NavigationBar

### DIFF
--- a/systems/web/src/components/react/NavigationBar.tsx
+++ b/systems/web/src/components/react/NavigationBar.tsx
@@ -5,6 +5,7 @@ import MenuOpenIcon from '@mui/icons-material/MenuOpen';
 import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined';
 import QuizOutlinedIcon from '@mui/icons-material/QuizOutlined';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import WorkHistoryOutlinedIcon from '@mui/icons-material/WorkHistoryOutlined';
 import AppBar from '@mui/material/AppBar';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
@@ -68,6 +69,25 @@ export function DrawerToggleButton({ title }: { title: string }) {
               />
             </ListItemButton>
           </ListItem>
+          <List component="div">
+            <ListItemButton
+              component={'a'}
+              href={'/portfolio/resume'}
+              sx={{ pl: 8 }}
+            >
+              <ListItemIcon>
+                <WorkHistoryOutlinedIcon
+                  sx={{
+                    color: 'action.active',
+                    transform: 'scale(1.7)',
+                  }}
+                />{' '}
+              </ListItemIcon>
+              <ListItemText
+                primary={<Typography variant={'body1'}>Resume</Typography>}
+              />
+            </ListItemButton>
+          </List>
           <ListItem>
             <ListItemButton component={'a'} href={'/portfolio/core-values'}>
               <ListItemIcon>

--- a/systems/web/src/components/who-am-i/react/SummarySection.tsx
+++ b/systems/web/src/components/who-am-i/react/SummarySection.tsx
@@ -1,7 +1,9 @@
+import WorkHistoryOutlinedIcon from '@mui/icons-material/WorkHistoryOutlined';
 import Avatar from '@mui/material/Avatar';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
+import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 
 export default function SummarySection({
@@ -25,6 +27,17 @@ export default function SummarySection({
       title={'Summary'}
     >
       <CardHeader
+        action={
+          <a href={'/portfolio/resume'}>
+            <IconButton aria-label="resume" size={'large'}>
+              <WorkHistoryOutlinedIcon
+                sx={{
+                  transform: 'scale(1.5)',
+                }}
+              />
+            </IconButton>
+          </a>
+        }
         avatar={<Avatar alt={name} src={profilePicture} />}
         component={'header'}
         subheader={position}


### PR DESCRIPTION
this close #38
Added a new "Resume" link with a WorkHistoryOutlinedIcon in the SummarySection component. Updated the NavigationBar to include a list item linking to the resume page for better accessibility.