### PR TITLE
GH-62: Remove redundant workflow_dispatch trigger from workflow

### DIFF
--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -26,9 +26,6 @@ on:
   push:
     branches:
       - main
-
-
-  workflow_dispatch: true
 permissions:
   contents: write
   id-token: write


### PR DESCRIPTION
this close #62
The workflow_dispatch trigger was unused and has been removed to streamline the workflow configuration. This change simplifies the file and ensures clarity without altering functionality.