### PR TITLE
GH-68: Remove sensitive Stripe keys from build script logging

### DIFF
--- a/systems/web/scripts/docker/build.sh
+++ b/systems/web/scripts/docker/build.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-echo "WEB_STRIPE_PUBLISHABLE_KEY: $WEB_STRIPE_PUBLISHABLE_KEY"
-echo "WEB_STRIPE_SECRET_KEY: $WEB_STRIPE_SECRET_KEY"
-
 npx astro build


### PR DESCRIPTION
this close #68
The build script no longer logs Stripe publishable and secret keys to prevent accidental exposure. This change enhances security by avoiding sensitive data output during the build process.