### PR TITLE
GH-58: Add manual trigger for GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-gh-page.yml
+++ b/.github/workflows/deploy-gh-page.yml
@@ -26,6 +26,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
+
 permissions:
   contents: write
   id-token: write


### PR DESCRIPTION
this part of #58
Enabled `workflow_dispatch` to allow manual triggering of the deployment workflow. This provides flexibility to initiate deployments outside of the automated push events.