### PR TITLE
GH-80: Add CMS data validation tests and improve sanitization utility

### DIFF
--- a/systems/prompts/.gitignore
+++ b/systems/prompts/.gitignore
@@ -1,9 +1,3 @@
-# build output
-dist/
-
-# generated types
-.astro/
-
 # dependencies
 node_modules/
 
@@ -22,3 +16,5 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+src/chat.js

--- a/systems/tests/tests/cms.ts
+++ b/systems/tests/tests/cms.ts
@@ -1,8 +1,81 @@
 import { formatGqlQuery, gql } from './graphql.ts';
+import { sanitise } from './test-helper.ts';
 
 const cmsBaseUrl = process.env['TESTS_CMS_BASE_URL'];
 if (!cmsBaseUrl) {
   throw new Error('TESTS_CMS_BASE_URL is not defined');
+}
+
+function covertRichTextFieldToAriaYml(
+  richTextField: Record<string, any>,
+  indent = 2,
+): string {
+  const INDENT_SPACE = ' '.repeat(indent);
+
+  function processNode(node: any, currentIndent: string): string {
+    if (!node || !node.type) return '';
+
+    switch (node.type) {
+      case 'h1': // Heading Level 1
+      case 'h2': // Heading Level 2
+      case 'h3': // Heading Level 3
+      case 'h4': // Heading Level 4
+      case 'h5': // Heading Level 5
+      case 'h6': {
+        // Heading Level 6
+        const headingText = sanitise(collectText(node.children));
+        const level = parseInt(node.type.replace('h', ''), 10); // Extract heading level
+        return `${currentIndent}- heading "${headingText}" [level=${level}]`;
+      }
+
+      case 'li': // List Item
+        return processNode(node.children[0], currentIndent); // Process inner "lic"
+
+      case 'lic': {
+        // List Item Content
+        const listItemText = sanitise(collectText(node.children));
+        return `${currentIndent}- listitem: ${listItemText}`;
+      }
+
+      case 'p': {
+        // Paragraph
+        const paragraphText = sanitise(collectText(node.children));
+        return `${currentIndent}- paragraph: "${paragraphText}"`;
+      }
+
+      case 'text': // Text Node
+        return sanitise(node.text || '');
+
+      case 'ul': {
+        // Unordered List
+        const listItems = node.children
+          .map((child: any) => processNode(child, currentIndent + INDENT_SPACE))
+          .filter(Boolean)
+          .join('\n');
+        return `${currentIndent}- list:\n${listItems}`;
+      }
+
+      default:
+        return ''; // Ignore unknown types
+    }
+  }
+
+  function collectText(children: any[]): string {
+    return children
+      .map((child: any) => {
+        if (child.type === 'text') return child.text;
+        if (child.children) return collectText(child.children);
+        return '';
+      })
+      .join('');
+  }
+
+  const result = richTextField['children']
+    .map((child: any) => processNode(child, INDENT_SPACE))
+    .filter(Boolean)
+    .join('\n');
+
+  return result;
 }
 
 function gqlRequest(query: ReturnType<typeof gql>, variables?: unknown) {
@@ -20,4 +93,4 @@ function gqlRequest(query: ReturnType<typeof gql>, variables?: unknown) {
   });
 }
 
-export default { gqlRequest };
+export default { covertRichTextFieldToAriaYml, gqlRequest };

--- a/systems/tests/tests/faq/faq.spec.ts
+++ b/systems/tests/tests/faq/faq.spec.ts
@@ -1,8 +1,12 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
+import cms from '../cms.ts';
+import { sanitise } from '../test-helper.ts';
 import { faqPage } from '../web.ts';
+import { replicateFrontendCMSQuery } from './query.graphql.ts';
 
+const cmsData = await replicateFrontendCMSQuery();
 test.describe('FAQ page flow', () => {
   test('Automatically detectable accessibility issues should be 0', async ({
     page,
@@ -12,5 +16,19 @@ test.describe('FAQ page flow', () => {
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 
     expect(accessibilityScanResults.violations).toEqual([]);
+  });
+  cmsData.page.questions.map((question: { answer: any; question: string }) => {
+    test(`${question.question} should exist and match the structure`, async ({
+      page,
+    }) => {
+      await page.goto(faqPage.toString());
+      const questionOnPage = page.getByRole('article', {
+        name: question.question,
+      });
+      const calculatedAriaSnapshot = `- article "${question.question}":
+  - heading "${sanitise(question.question)}" [level=3]
+${cms.covertRichTextFieldToAriaYml(question.answer, 2)}`;
+      await expect(questionOnPage).toMatchAriaSnapshot(calculatedAriaSnapshot);
+    });
   });
 });

--- a/systems/tests/tests/skills/skills.spec.ts
+++ b/systems/tests/tests/skills/skills.spec.ts
@@ -1,7 +1,11 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
+import cms from '../cms.ts';
 import { skillsPage } from '../web.ts';
+import { replicateFrontendCMSQuery } from './query.graphql.ts';
+
+const cmsData = await replicateFrontendCMSQuery();
 
 test.describe('Skills page flow', () => {
   test('Automatically detectable accessibility issues should be 0', async ({
@@ -13,4 +17,22 @@ test.describe('Skills page flow', () => {
 
     expect(accessibilityScanResults.violations).toEqual([]);
   });
+  cmsData.page.skillsRef.sections.map(
+    (section: { description: any; section: string; tags: string[] }) => {
+      test(`${section.section} should exist and match the structure`, async ({
+        page,
+      }) => {
+        await page.goto(skillsPage.toString());
+        const sectionOnPage = page.getByRole('article', {
+          name: section.section,
+        });
+        const calculatedAriaSnapshot = `- article "${section.section}":
+${cms.covertRichTextFieldToAriaYml(section.description, 2)}
+  - separator
+  - list:
+${section.tags.map((tag: string) => `    - listitem: ${tag}`).join('\n')}`;
+        await expect(sectionOnPage).toMatchAriaSnapshot(calculatedAriaSnapshot);
+      });
+    },
+  );
 });

--- a/systems/tests/tests/test-helper.ts
+++ b/systems/tests/tests/test-helper.ts
@@ -1,3 +1,3 @@
 export function sanitise(source: string) {
-  return source.replaceAll('\n', ' ');
+  return source.trim().replaceAll('\n', ' ');
 }


### PR DESCRIPTION
this close #80
This commit introduces tests to validate CMS data-driven FAQ and Skills page structures, ensuring they match expected accessibility and ARIA requirements. A `covertRichTextFieldToAriaYml` utility is added for ARIA snapshot generation. Additionally, the `sanitise` function is enhanced to trim input strings, improving data consistency.