### PR TITLE
GH-95: Add ADR for IaC tool evaluation: Pulumi vs Terraform CDK

### DIFF
--- a/docs/adr/20250212-iac-system.md
+++ b/docs/adr/20250212-iac-system.md
@@ -1,0 +1,78 @@
+# Selection of Infrastructure as Code (IaC) Tool: Pulumi vs Terraform CDK
+
+- Status: Proposed
+- Decider: [Your Name]
+- Date: [YYYY-MM-DD] <!-- Replace with the actual date -->
+
+## Context and Problem Statement
+
+I need to own and manage a backend server (API) to enable the chat assistant feature for my frontend. My aim is to host this infrastructure using **Google Cloud Platform (GCP)** services, particularly **Cloud Run** for deploying Docker-based APIs. I’ve chosen GCP because AWS does not currently provide comparable pay-per-request hosting for Docker containers, and GCP’s **Cloud Run** and **Firebase** offer more attractive pay-per-request pricing and relevant features for my project.
+
+To efficiently manage and automate the provisioning of this GCP infrastructure, adopting **Infrastructure as Code (IaC)** is essential. The IaC tool must fulfill the following priorities:
+
+1. **Multi-cloud support** for potential future integrations or migrations.
+2. The ability to use **imperative programming languages** (e.g., TypeScript or Python) instead of DSLs.
+3. **Scalable state management** with minimal manual configuration.
+4. A developer-friendly setup that allows me to quickly onboard and start managing infrastructure effectively.
+
+This decision will guide my Proof-of-Concept (POC) implementation and future infrastructure provisioning workflows.
+
+## Decision Drivers
+
+- **GCP-Focused Infrastructure**: Key services include Cloud Run and Firebase, chosen for their functionality and pricing model.
+- **Pay-per-Request Pricing**: The pricing approach aligns with projected usage and budget constraints.
+- **Multi-Cloud Readiness**: Flexibility to extend infrastructure provisioning to other cloud providers like AWS or Azure in the future.
+- **Developer Workflows**: Preference for IaC tools that integrate well with programming languages and developer workflows for faster adoption.
+- **Simplicity in State Management**: A robust yet straightforward solution for handling state without significant configuration overhead.
+
+## Considered Options
+
+1. **Pulumi**
+2. **Terraform CDK**
+
+## Decision Outcome
+
+After reviewing the available options, I have decided to proceed with a **Proof-of-Concept (POC)** for both **Pulumi** and **Terraform CDK**. The decision on which tool to adopt long-term will be based on ease of integration with GCP services, alignment with decision drivers, and overall developer experience.
+
+### Positive Consequences
+
+- The infrastructure for my backend API and Firebase features can be automated and standardized, reducing manual overhead.
+- Both tools allow for easy adoption of modern programming languages, aligning with my existing skill set and workflows.
+- Multi-cloud support ensures my infrastructure provisioning remains flexible for future changes or integrations.
+
+### Negative Consequences
+
+- Learning curve and additional time required to evaluate both tools during the POC phase.
+- Potential long-term lock-in to the chosen tool’s ecosystem for managing infrastructure.
+
+## Pros and Cons of the Options
+
+### Pulumi
+
+- **Pros**:
+    - Supports programming languages like TypeScript, Python, Go, and C# in an imperative coding style.
+    - Integrated state management backend (Pulumi Service), with support for custom state storage (e.g., GCS, S3).
+    - Supports direct API integrations with GCP, enabling rapid adoption of new features.
+    - Developer-oriented with less boilerplate compared to Terraform CDK.
+
+- **Cons**:
+    - A smaller community compared to Terraform, which may result in fewer pre-built examples/modules.
+    - Pulumi-specific constructs may introduce migration challenges if switching tools in the future.
+
+### Terraform CDK
+
+- **Pros**:
+    - Large ecosystem of providers thanks to Terraform, with extensive support for GCP and other cloud services.
+    - Enables infrastructure coding with familiar programming languages (TypeScript, Python, Go, etc.).
+    - Stable and mature backend for state management due to Terraform’s long-standing presence.
+    - Ideal for tapping into Terraform's vast library of community-supported modules.
+
+- **Cons**:
+    - Initial setup for state backends like GCS requires more manual configuration compared to Pulumi.
+    - Dependent on Terraform HCL abstractions, which may limit fully imperative-style workflows.
+    - Slower adoption of GCP-specific updates compared to Pulumi, as Terraform relies on provider updates.
+
+## Links
+
+- Pulumi Documentation: [https://www.pulumi.com/docs/](https://www.pulumi.com/docs/)
+- Terraform CDK Documentation: [https://developer.hashicorp.com/terraform/cdktf](https://developer.hashicorp.com/terraform/cdktf)

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -4,8 +4,6 @@
 - Deciders: [list everyone involved in the decision] <!-- optional -->
 - Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
 
-Technical Story: [description | ticket/issue URL] <!-- optional -->
-
 ## Context and Problem Statement
 
 ## Decision Drivers <!-- optional -->


### PR DESCRIPTION
this close #95
Documented the context, decision drivers, and rationale for evaluating Pulumi and Terraform CDK as Infrastructure as Code tools. Established criteria for a Proof-of-Concept phase to determine the best fit for automating GCP infrastructure provisioning.