### PR TITLE
GH-119: Use inline script and update JSON resume source URL.

### DIFF
--- a/systems/web/src/components/resume/react/ResumeLoader.tsx
+++ b/systems/web/src/components/resume/react/ResumeLoader.tsx
@@ -5,7 +5,11 @@ export default function ResumeLoader() {
   return (
     <Paper>
       {/*@ts-expect-error No typing for web component*/}
-      <json-resume></json-resume>
+      <json-resume
+        src={'https://neviaumi.github.io/resume.json/resume.base.json'}
+      >
+        {/*@ts-expect-error No typing for web component*/}
+      </json-resume>
     </Paper>
   );
 }

--- a/systems/web/src/pages/resume.astro
+++ b/systems/web/src/pages/resume.astro
@@ -9,7 +9,7 @@ const title = "Resume"
 ---
 
 <Layout title={title} description="Explore David's resume, highlighting his skills and experience. Learn more about his professional background and qualifications.">
-    <script slot="extra" src="https://neviaumi.github.io/resume.json/json-resume.element.js" type="module" async defer/>
+    <script is:inline slot="extra" src="https://neviaumi.github.io/resume.json/json-resume.element.js" type="module" async defer/>
     <Page>
         <NavigationBar client:load title={title}/>
 


### PR DESCRIPTION
this close #119
Switched the script tag to inline mode to improve flexibility and updated the `json-resume` component to load a specific JSON source. This ensures the resume data is properly fetched and reduces potential issues with the component's configuration.