### PR TITLE
GH-130: Update volume configuration in docker-compose.build.yml

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -14,7 +14,9 @@ services:
     environment:
       VITE_JSON_RESUME_URL: http://web:4321/portfolio/resume.json
     volumes:
-      - source: ./dist
+      - bind:
+          create_host_path: true
+        source: ./dist
         target: /app/public
         type: bind
   web:


### PR DESCRIPTION
this close #130
Replaces shorthand volume definition with detailed bind options. Adds `create_host_path: true` to ensure the host path is created when missing, improving reliability.