### PR TITLE
GH-173: Refactor resume generation and introduce server API

### DIFF
--- a/systems/ai-assistant/README.md
+++ b/systems/ai-assistant/README.md
@@ -139,9 +139,9 @@ You can utilize the `ai-assistant` system for various purposes, including runnin
       ```bash
       node cli/commands/resume-summary.js
       ```
-    - To manage a CMS:
+    - To generate cord intro messages:
       ```bash
-      node cli/commands/cms.js
+      op run --env-file="./.env" -- node ./commands/cord-intro-messages.js
       ```
 
 Refer to specific command scripts in the `cli/commands` directory for more examples.

--- a/systems/ai-assistant/cli/.gitignore
+++ b/systems/ai-assistant/cli/.gitignore
@@ -2,3 +2,4 @@ commands/chat.js
 commands/chat.*.js
 assets/jd.txt
 assets/*.json
+assets/*.pdf

--- a/systems/ai-assistant/cli/commands/advise-question-to-ask.js
+++ b/systems/ai-assistant/cli/commands/advise-question-to-ask.js
@@ -1,0 +1,40 @@
+import * as openAi from './open-ai.js';
+import { getAssetContent } from './workspace.js';
+
+const jd = await getAssetContent('jd.txt');
+
+// Define the specific job/title of the person conducting the interview
+const interviewerPosition = 'Talent Lead'; // Examples: 'Engineering Team', 'CTO', 'HR Manager', etc.
+
+const prompts = [
+  openAi.jdSystem,
+  await openAi.loadPortfolioIntoPrompts(),
+  await openAi.processJD(jd).then(openAi.loadJDIntoPrompts),
+  {
+    content: `Please generate **up to 4 thoughtful and specific questions**, categorized under appropriate themes, using **simple and clear English**, 
+      that I can ask at the end of an interview with a **${interviewerPosition}** (the company representative conducting the interview). 
+      
+      Your response should:
+      
+      1. Be tailored to the JD and the company's focus areas (e.g., tech stack, product, or culture).
+      2. Address aspects most relevant to the **${interviewerPosition}'s** expertise, responsibilities, or perspective.
+      3. Reflect curiosity, critical thinking, and genuine enthusiasm for the position.
+      4. Organize questions under the most relevant themes, such as:
+         - **Technical Work** (if applicable): Questions about technical challenges and team processes.
+         - **Role-Specific**: Questions clarifying role expectations, success factors, or growth opportunities.
+         - **Culture and Welfare**: Questions about company culture, inclusivity, employee development, and work-life balance.
+         - **Leadership and Management** (if applicable): Questions about decision-making, collaboration, or leadership styles.
+
+      Examples of questions for each theme:
+      - **Technical Work**: What are the most significant technical challenges your team is solving right now?  
+      - **Role-Specific**: What does success look like for this role, and how is it measured?  
+      - **Culture and Welfare**: How does your company support employees’ well-being or career growth?  
+      - **Leadership and Management**: Can you share how leadership fosters collaboration across teams?
+
+      Using this structure, **categorize** your response into the relevant themes based on the provided **${interviewerPosition}** and generate a maximum of 4 insightful, specific, and compelling questions.
+    `,
+    role: 'user',
+  },
+];
+
+openAi.prompt(prompts).then(openAi.readMessageFromPrompt).then(console.log);

--- a/systems/ai-assistant/cli/commands/generate-cover-letter.js
+++ b/systems/ai-assistant/cli/commands/generate-cover-letter.js
@@ -1,0 +1,20 @@
+import * as openAi from './open-ai.js';
+import { getAssetContent } from './workspace.js';
+
+const jd = await getAssetContent('jd.txt');
+const prompts = [
+  openAi.jdSystem,
+  await openAi.loadPortfolioIntoPrompts(),
+  await openAi.processJD(jd).then(openAi.loadJDIntoPrompts),
+  {
+    content: `I will share my draft cover letter in the next prompt. 
+      Please review and rewrite it using **simple and clear English** 
+`,
+    role: 'user',
+  },
+];
+
+openAi
+  .withFeedbackLoop(openAi.prompt)(prompts)
+  .then(openAi.readMessageFromPrompt)
+  .then(console.log);

--- a/systems/ai-assistant/cli/commands/resume.js
+++ b/systems/ai-assistant/cli/commands/resume.js
@@ -1,0 +1,25 @@
+const resumeBuilderUrl = 'http://localhost:8080';
+
+export function generateTailoredResumePdf(tailoredResumeJsonId) {
+  return fetch(
+    new URL(
+      `/api/resume/resume-to-pdf?tailorResumeId=${tailoredResumeJsonId}`,
+      resumeBuilderUrl,
+    ),
+    {
+      method: 'GET',
+    },
+  ).then(res => res.body);
+}
+
+export function generateTailoredATSResumePdf(tailoredResumeJsonId) {
+  return fetch(
+    new URL(
+      `/api/resume/ats-resume-to-pdf?tailorResumeId=${tailoredResumeJsonId}`,
+      resumeBuilderUrl,
+    ),
+    {
+      method: 'GET',
+    },
+  ).then(res => res.body);
+}

--- a/systems/resume/Dockerfile
+++ b/systems/resume/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.50.1 AS base
 
 WORKDIR /app
 
-COPY ./package.json ./package-lock.json ./index.html ./vite.config.js ./resume-to-pdf.js ./resume-to-latex.js ./workspace.js ./
+COPY ./package.json ./package-lock.json ./index.html ./vite.config.js ./resume-to-pdf.js ./resume-to-latex.js ./workspace.js ./server.js ./
 COPY ./scripts/docker/ ./scripts/docker/
 COPY ./public/ ./public/
 

--- a/systems/resume/scripts/docker/start.sh
+++ b/systems/resume/scripts/docker/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+node ./server.js

--- a/systems/resume/server.js
+++ b/systems/resume/server.js
@@ -1,0 +1,105 @@
+import { exec as _exec } from 'node:child_process';
+import fs from 'node:fs/promises';
+// Import the built-in http module
+import { createServer } from 'node:http';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { fetchResumeJson, resumeToLatex } from './resume-to-latex.js';
+import { generateResumeToPDF } from './resume-to-pdf.js';
+import { PUBLIC_FOLDER } from './workspace.js';
+
+const exec = promisify(_exec);
+async function handleATSResumeToPDF(req, res) {
+  const { headers, url } = req;
+  const requestUrl = new URL(url, `http://${headers['host']}`);
+  const tailorResumeId = requestUrl.searchParams.get('tailorResumeId');
+  process.env['VITE_RESUME_SOURCE'] = `${tailorResumeId}.json`;
+  const pdfPath = path.join(PUBLIC_FOLDER, `ats-${tailorResumeId}.pdf`);
+  await fetchResumeJson()
+    .then(resumeToLatex)
+    .then(resumeLatex =>
+      fs.writeFile(`${PUBLIC_FOLDER}/${tailorResumeId}.tex`, resumeLatex),
+    );
+  await exec(
+    `(cd ${PUBLIC_FOLDER} && pdflatex -jobname="ats-${tailorResumeId}" ${tailorResumeId}.tex)`,
+  );
+  fs.readFile(pdfPath)
+    .then(content => {
+      res.writeHead(200, {
+        'Content-Disposition': `attachment; filename="ats-${tailorResumeId}.pdf"`,
+        'Content-Type': 'application/pdf',
+      });
+      res.end(content);
+    })
+    .catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Could not read the generated PDF',
+          message: err.message,
+        }),
+      );
+    });
+}
+
+async function handleResumeToPDF(req, res) {
+  const { headers, url } = req;
+  const requestUrl = new URL(url, `http://${headers['host']}`);
+  const tailorResumeId = requestUrl.searchParams.get('tailorResumeId');
+  process.env['VITE_RESUME_SOURCE'] = `${tailorResumeId}.json`;
+  const pdfPath = path.join(PUBLIC_FOLDER, `${tailorResumeId}.pdf`);
+  await generateResumeToPDF(path.join(PUBLIC_FOLDER, `${tailorResumeId}.pdf`));
+  fs.readFile(pdfPath)
+    .then(content => {
+      res.writeHead(200, {
+        'Content-Disposition': `attachment; filename="${tailorResumeId}.pdf"`,
+        'Content-Type': 'application/pdf',
+      });
+      res.end(content);
+    })
+    .catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error: 'Could not read the generated PDF',
+          message: err.message,
+        }),
+      );
+    });
+}
+
+// Create the HTTP server
+const server = createServer(async (req, res) => {
+  const { headers, method, url } = req;
+  const requestUrl = new URL(url, `http://${headers['host']}`);
+  // Set the default headers for the response
+  res.setHeader('Content-Type', 'application/json');
+
+  const routeExists =
+    ['/api/resume/ats-resume-to-pdf', '/api/resume/resume-to-pdf'].includes(
+      requestUrl.pathname,
+    ) && method === 'GET';
+
+  if (!routeExists) {
+    // Handle 404 for unhandled routes
+    res.writeHead(404);
+    res.end(JSON.stringify({ error: 'Route not found' }));
+    return;
+  }
+  if (requestUrl.pathname === '/api/resume/resume-to-pdf') {
+    await handleResumeToPDF(req, res);
+  }
+  if (requestUrl.pathname === '/api/resume/ats-resume-to-pdf') {
+    await handleATSResumeToPDF(req, res);
+  }
+});
+
+// Define the port to listen on
+const PORT = 8080;
+
+process.env['VITE_IS_TAILORED_RESUME'] = JSON.stringify(true);
+// Start the server
+server.listen(PORT, () => {
+  console.log(`Server is running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
this close #173
Separated PDF and LaTeX generation logic from script entry points to reusable functions and added a standalone HTTP server for resume-related operations. The server provides endpoints for tailored resume generation, improving modularity and automation capabilities. Additional changes include updates to Dockerfile, ignore files, and CLI commands to support new features.