### PR TITLE
GH-173: Replace local temp file handling with resume JSON upload API

### DIFF
--- a/systems/ai-assistant/cli/commands/resume.js
+++ b/systems/ai-assistant/cli/commands/resume.js
@@ -1,5 +1,14 @@
 const resumeBuilderUrl = 'http://localhost:8080';
 
+export function uploadResumeJson(id, resumeJson) {
+  return fetch(new URL(`/api/resume/${id}`, resumeBuilderUrl), {
+    body: JSON.stringify(resumeJson),
+    method: 'POST',
+  }).then(res => {
+    if (!res.ok) throw new Error(res.statusText);
+  });
+}
+
 export function generateTailoredResumePdf(tailoredResumeJsonId) {
   return fetch(
     new URL(

--- a/systems/ai-assistant/cli/commands/tailor-resume-json.js
+++ b/systems/ai-assistant/cli/commands/tailor-resume-json.js
@@ -1,6 +1,5 @@
 import _fs from 'node:fs';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { scheduler } from 'node:timers/promises';
 
@@ -9,12 +8,12 @@ import * as openAI from './open-ai.js';
 import {
   generateTailoredATSResumePdf,
   generateTailoredResumePdf,
+  uploadResumeJson,
 } from './resume.js';
 import * as web from './web.js';
 import {
   ASSETS_FOLDER,
   getAssetContent,
-  getTempDirectory,
   resolveAssetPath,
 } from './workspace.js';
 
@@ -343,10 +342,7 @@ await generateTailoredProject().then(projects =>
 );
 await scheduler.wait(5000);
 
-await fs.writeFile(
-  path.join(getTempDirectory(), `${jdJson.id}.json`),
-  JSON.stringify(defaultResume, null, 2),
-);
+await uploadResumeJson(jdJson.id, defaultResume);
 
 await generateTailoredATSResumePdf(jdJson.id).then(data =>
   pipeline(

--- a/systems/ai-assistant/cli/commands/workspace.js
+++ b/systems/ai-assistant/cli/commands/workspace.js
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
-export const getTempDirectory = (...args) => os.tmpdir(...args);
 export const WORKSPACE_ROOT = path.join(
     path.resolve(import.meta.dirname),
     '../',


### PR DESCRIPTION
this part of #173
This update introduces a new API for uploading resume JSON data instead of saving it to a temporary file locally. The `uploadResumeJson` function was added, and corresponding server-side endpoints now handle file uploads. This change reduces filesystem dependency and improves modularity.